### PR TITLE
chore: add LICENSE.md and _pkgdown.yml to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,4 +12,6 @@
 ^new_code$
 ^docs$
 ^\.cursorrules$
-^\.travis.yml$
+^\.travis\.yml$
+^LICENSE\.md$
+^_pkgdown\.yml$


### PR DESCRIPTION
## Summary

Suppress R CMD check NOTE about non-standard top-level files.

## Changes

- Add `^LICENSE\.md$` and `^_pkgdown\.yml$` to `.Rbuildignore`

## Verification

These are standard development files that should not be included
in the built R package.

## Notes

The "future file timestamps" NOTE is a CI environment issue and
cannot be fixed (it's harmless).