### PR TITLE
refactor: standardize internal function naming to dot convention

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -973,7 +973,7 @@ if (f == "plot") { # check plotting arguments
 #' @return No return value. Instead, the function returns standardized
 #'   data frames and a vector of unique genes to the specified environment.
 #' @noRd
-.file_set <- function(OI, SI, SO, pos.info, ENV) {
+.set.files <- function(OI, SI, SO, pos.info, ENV) {
    # copy files to avoid overwriting
    OI <- data.table::copy(OI)
    SI <- data.table::copy(SI)
@@ -1025,7 +1025,7 @@ if (f == "plot") { # check plotting arguments
 #' @return No return value. Instead, the function transforms data.tables
 #'   within specified environment.
 #' @noRd
-.file_reset <- function(OI, SI, SO, pos.info) {
+.reset.files <- function(OI, SI, SO, pos.info) {
    # remove keys
    data.table::setkey(OI, NULL)
    data.table::setkey(SI, NULL)
@@ -1069,7 +1069,7 @@ if (f == "plot") { # check plotting arguments
 #' @return list containing data.table with gene scores and separate data.table
 #'  with raw maximum scores and model parameters as an attribute.
 #' @noRd
-.get_obj_stat <- function(OI, VI, FUN, binN) {
+.get.object.stats <- function(OI, VI, FUN, binN) {
    # overlap gene bins and SNPs
    oiX <- data.table::copy(OI)[, .(chr, objID, startpos, endpos)] # avoid overwriting obj.info
    oiX <- oiX[VI, on = .(chr = chr, startpos <= pos, endpos >= pos), nomatch = 0]
@@ -1174,7 +1174,7 @@ if (f == "plot") { # check plotting arguments
 #' @return A data.table with two columns, `setID` (the original set ID) and
 #'  `setID.new` (the final set ID).
 #' @noRd
-.final_merge <- function(I, J) {
+.merge.final <- function(I, J) {
    # find sets that have been merged multiple times
    mgm <- merge(I, J, by.x = "setID.new", by.y = "setID", all.y = TRUE)
    K <- mgm[, .(setID = ifelse(is.na(setID), setID.new, setID),
@@ -1196,7 +1196,7 @@ if (f == "plot") { # check plotting arguments
 #' @return An `integer` vector where each value represents the subnetwork ID for
 #'  each gene set.
 #' @noRd
-.get_subnetworks <- function(SO, min.sim) {
+.get.subnetworks <- function(SO, min.sim) {
    # no. of shared genes between sets
    SxG <- SO[SO, on = .(objID = objID),
              allow.cartesian = TRUE][, .N, keyby = .(setID, i.setID)]
@@ -1234,11 +1234,11 @@ if (f == "plot") { # check plotting arguments
 #'  provided environment (`ENV`) by adding the updated `set.info` and `set.obj`
 #'  tables, as well as generating an object tracking the merged sets.
 #' @noRd
-.merge_sim_sets <- function(SI, SO, min.sim, ENV) {
+.merge.similar.sets <- function(SI, SO, min.sim, ENV) {
    SI[, setN := SO[, .N, keyby = setID]$N] # get gene set size
 
    # identify subnetworks of gene sets with shared genes
-   SI0 <- .get_subnetworks(SO = SO, min.sim = min.sim)
+   SI0 <- .get.subnetworks(SO = SO, min.sim = min.sim)
    merged.sets <- list()
    R <- 0
 
@@ -1260,14 +1260,14 @@ if (f == "plot") { # check plotting arguments
       SI[, setN := SO[, .N, keyby = setID]$N] # update set sizes
 
       # check that new sets fulfill merging requirements
-      SI0 <- .get_subnetworks(SO = SO, min.sim = min.sim)
+      SI0 <- .get.subnetworks(SO = SO, min.sim = min.sim)
    }
 
    # prepare output
    if (R == 0) {
       SO.xx <- NULL
    } else { # compile final merged sets
-      SO.xx <- Reduce(.final_merge, merged.sets)
+      SO.xx <- Reduce(.merge.final, merged.sets)
       if ("setName" %in% names(SI)) {
          SI[SO.xx, on = .(setID = setID.new), setName := paste0(setName, "!")]
       }
@@ -1317,7 +1317,7 @@ if (f == "plot") { # check plotting arguments
 #' @return A matrix where all probabilities are at or below `maxP` and each
 #'  row sums to 1.
 #' @noRd
-.cap_probs <- function(mm0, maxP) {
+.cap.probabilities <- function(mm0, maxP) {
    wS <- Rfast::rowsums(mm0) # get row weight sums
    wMax <- maxP * wS # maximum weight in each row
    wGT0 <- which(mm0 > wMax, arr.ind = TRUE) # check that capping is required
@@ -1584,7 +1584,7 @@ if (f == "plot") { # check plotting arguments
 #' @param n.genes integer; Number of genes used in permutations.
 #' @return Numeric matrix `K` of size length(x) by length(x) with unit diagonal.
 #' @noRd
-.est_ss_cov <- function(x, n.genes) {
+.estimate.setsize.covariance <- function(x, n.genes) {
    denom <- tcrossprod(sqrt(x * (n.genes - x)))
    num_min <- outer(x, x, pmin) # min(i,j)
    num_max <- outer(x, x, pmax) # max(i,j)
@@ -1741,7 +1741,7 @@ Predict.matrix.wls.smooth <- function(object, data) {
 #'  small genomic distances—where autocovariance structure is strongest—while
 #'  maintaining statistical stability at larger lags.
 #' @noRd
-.get_cgm_bins <- function (maxL, minL, cgm.bin, OI) {
+.get.correlogram.bins <- function (maxL, minL, cgm.bin, OI) {
    n.chr <- length(OI)
    min.log <- log10(1e5 * minL) # minimum possible lag range
    max.log <- log10(5e7 * minL) # maximum possible lag range
@@ -2002,7 +2002,7 @@ Predict.matrix.wls.smooth <- function(object, data) {
 #' @return A data.table of autocovariances (`C`) for each null gene set (`sID`)
 #'   and by successive set sizes (`sN`)
 #' @noRd
-.get_covariance_null <- function(csj, rsX, set_scores, autocov_data) {
+.get.null.covariance <- function(csj, rsX, set_scores, autocov_data) {
    SSi <- set_scores[, oID := c(csj)]
    ACx <- autocov_data[SSi, on = .(A = oID), nomatch = 0, allow.cartesian = TRUE]
    ACxx <- ACx[SSi, on = .(B = oID, sID = sID), nomatch = 0]
@@ -2022,7 +2022,7 @@ Predict.matrix.wls.smooth <- function(object, data) {
 #' @import data.table
 #' @return A data.table of autocovariances (`C`) for each null gene set (`sID`)
 #' @noRd
-.get_covariance <- function(SSi, autocov_data) {
+.get.covariance <- function(SSi, autocov_data) {
    # extract covariances
    ACx <- autocov_data[SSi, on = .(A = oID), nomatch = 0, allow.cartesian = TRUE]
    ACxx <- ACx[SSi, on = .(B = oID, sID = sID), nomatch = 0]
@@ -2059,7 +2059,7 @@ Predict.matrix.wls.smooth <- function(object, data) {
    rescaled <- !is.null(acX)
    if (rescaled) { # track autocovariance
       cX <- rep(0, n.set.rem)
-      cx0 <- .get_covariance(SSi = PI[A == B, .(sID = A, oID = X)], autocov_data = acX)
+      cx0 <- .get.covariance(SSi = PI[A == B, .(sID = A, oID = X)], autocov_data = acX)
       cX[cx0$sID] <- cx0$CV
    }
 
@@ -2352,14 +2352,14 @@ Predict.matrix.wls.smooth <- function(object, data) {
 #' @keywords internal
 #' @noRd
 .get_cov0 <- function(...) {
-   .get_covariance_null(...)
+   .get.null.covariance(...)
 }
 
 #' @rdname get_covariance
 #' @keywords internal
 #' @noRd
 .get_cov <- function(...) {
-   .get_covariance(...)
+   .get.covariance(...)
 }
 
 #' @rdname prune_gene_sets

--- a/R/permute.R
+++ b/R/permute.R
@@ -244,7 +244,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
    set.seed(seed)
 
    # ensure contiguous IDs for genes and sets
-   .file_set(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
+   .set.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
              ENV = environment())
 
    # set up for parallel back end and reporting
@@ -359,7 +359,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
                    globals = c("M0", "kern.bound",  "kern.scale", "kern.func",
                                "kern.wt.max", "n.cov", "n.genes", "os0", "ov0",
                                "cv.val", "cv.var", "prog", ".fit_lqr",
-                               ".cap_probs", ".md2p"), seed = seed)
+                               ".cap.probabilities", ".md2p"), seed = seed)
 
       progressr::with_progress({
          prog <- progressr::progressor(steps = n.ch)
@@ -391,7 +391,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
 
                # calculate probability weights
                if (kern.wt.max < 1) { # apply probability cap
-                  wt.i <- .cap_probs(mm0 = wt.i, maxP = kern.wt.max)
+                  wt.i <- .cap.probabilities(mm0 = wt.i, maxP = kern.wt.max)
                } else {
                   wt.i <- wt.i / Rfast::rowsums(wt.i)
                }
@@ -613,7 +613,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
          .verbose_msg(paste("Smoothing empirical CDF and GPD parameter estimates",
                     "and interpolating missing values\n"))
 
-         K <- .est_ss_cov(x = th0, n.genes = n.genes) # covariance matrix
+         K <- .estimate.setsize.covariance(x = th0, n.genes = n.genes) # covariance matrix
          sm.k <- min(max(10, round(n.th / 4)), 40) # deterministic basis for gam smoother
          sm0 <- mgcv::smoothCon(mgcv::s(x, k = sm.k, bs = "ps"),
                                 data = data.frame(x = log(th0)))[[1]] # get inner smoothing function
@@ -781,7 +781,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
    plr.session$permute.session <- permute.session
 
    # set s3 class and create attributes
-   .file_reset(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
+   .reset.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
    OUT <- list(set.info = set.info, obj.info = obj.info, set.obj = set.obj)
    plr.out <- .new_plr(BASE = OUT, plr_data = plr.data, plr_args = plr.args,
                        plr_summary = plr.summary, plr_seed = plr.seed,

--- a/R/prune.R
+++ b/R/prune.R
@@ -150,7 +150,7 @@ prune_polylinkr_data <- function(plr_input, n_fdr = 300L, estimate_pi0 = TRUE,
    set.seed(seed) # reinstate seed from plR_permute
 
    # ensure contiguous IDs for genes and sets
-   .file_set(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
+   .set.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
              ENV = environment())
 
    # set up for parallel back end and reporting
@@ -229,7 +229,7 @@ prune_polylinkr_data <- function(plr_input, n_fdr = 300L, estimate_pi0 = TRUE,
 
       FDR.pr[[4]] <- foreach::foreach(f.i = fdr.perm, F.i = FDR, .combine = c) %do% {
          ss.i <- soi[, .(sID, oID = f.i[oID])]
-          cov.i <- .get_covariance(SSi = ss.i, autocov_data = ac0)
+          cov.i <- .get.covariance(SSi = ss.i, autocov_data = ac0)
          sN0 <- sN[cov.i$sID]
          c.i[cov.i$sID] <- cov.i$CV
          F.i / sqrt((sN + c.i) * fpc[sN])
@@ -470,7 +470,7 @@ prune_polylinkr_data <- function(plr_input, n_fdr = 300L, estimate_pi0 = TRUE,
    plr.session$prune.session <- list(session = sessionInfo(), run.time = r0[[2]])
 
    # set s3 class and create attributes
-   .file_reset(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
+   .reset.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
    OUT <- list(set.info = set.info, obj.info = obj.info, set.obj = set.obj)
    plr.out <- .new_plr(BASE = OUT, plr_data = plr.data, plr_args = plr.args,
                        plr_summary = plr.summary, plr_seed = plr.seed,

--- a/R/read.R
+++ b/R/read.R
@@ -861,7 +861,7 @@ read_polylinkr_data <- function(input_path = NULL, object_info_path = NULL,
                      "|overlap|`\n"))
 
          # generate maximum scores in each gene interval
-         os0 <- .get_obj_stat(OI = obj.info, VI = var.info,
+         os0 <- .get.object.stats(OI = obj.info, VI = var.info,
                               FUN = obj.stat.fun, binN = bin.size)
          obj.info[os0[[1]], on = .(objID), objStat := objMax.res]
          obj.stat.param <- os0[[2]]
@@ -968,7 +968,7 @@ read_polylinkr_data <- function(input_path = NULL, object_info_path = NULL,
       }
 
       # run merging function
-      .merge_sim_sets(SI = data.table::copy(set.info),
+      .merge.similar.sets(SI = data.table::copy(set.info),
                       SO = data.table::copy(set.obj),
                       min.sim = set.merge, ENV = environment())
 

--- a/R/rescale.R
+++ b/R/rescale.R
@@ -213,7 +213,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
    set.seed(seed) # reinstate seed from plR_permute
 
    # ensure contiguous IDs for genes and sets
-   .file_set(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
+   .set.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info,
              ENV = environment())
 
    # set up for parallel back end and reporting
@@ -291,7 +291,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
 
       oi0 <- oi0[order(startpos, endpos)]
       oi0 <- split(oi0, oi0$chr)
-      cBins <- .get_cgm_bins(maxL = maxL, minL = minL,
+      cBins <- .get.correlogram.bins(maxL = maxL, minL = minL,
                              cgm.bin = cgm.bin, OI = oi0)
       nBins <- length(cBins) - 1
 
@@ -366,7 +366,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
       if (cgm.wt.max < cgm.wt.min) cgm.wt.max <- cgm.wt.min
 
       cN[, lag.wts := (N / bin.size), by = chr] # gene density
-      cN[, lag.wts := .cap_probs(matrix(lag.wts, nrow = 1),
+      cN[, lag.wts := .cap.probabilities(matrix(lag.wts, nrow = 1),
                                         maxP = cgm.wt.max), by = chr] # avoid too much emphasis on smallest category
       cN[, bin := match(bin, bin) - 1] # set 0-lag bin index to 0
 
@@ -621,7 +621,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
                      dqrng::dqset.seed(x)
                      csX <- replicate(n.block,
                                       dqrng::dqsample.int(n.genes, n.max)) # faster than dqsample::dqsample
-                      rsX <- .get_covariance_null(csj = csX, rsX = rs0, set_scores = SS0, autocov_data = ac0) # get covariances
+                      rsX <- .get.null.covariance(csj = csX, rsX = rs0, set_scores = SS0, autocov_data = ac0) # get covariances
                      csX <- matrix(os0[csX], nrow = n.max, ncol = n.block) # get gene scores
 
                      if (n.sets == 1) { # only take final entry
@@ -700,7 +700,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
             .verbose_msg(paste("Smoothing empirical CDF and GPD parameter estimates",
                        "and interpolating missing values\n"))
 
-            K <- .est_ss_cov(x = th0, n.genes = n.genes) # covariance matrix
+            K <- .estimate.setsize.covariance(x = th0, n.genes = n.genes) # covariance matrix
             sm.k <- min(max(10, round(n.th / 4)), 40) # deterministic basis for gam smoother
             sm0 <- mgcv::smoothCon(mgcv::s(x, k = sm.k, bs = "ps"),
                                    data = data.frame(x = log(th0)))[[1]] # get inner smoothing function
@@ -837,7 +837,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
       ac0 <- ac[, .(A = objID.A, B = objID.B, CV = 2 * rho)]
 
       obs.cov <- rep(0, n.sets)
-       oc0 <- .get_covariance(SSi = SSI, autocov_data = ac0)
+       oc0 <- .get.covariance(SSi = SSI, autocov_data = ac0)
       obs.cov[oc0$sID] <- oc0$CV
 
       # calculate observed rescaled set scores
@@ -904,7 +904,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
    plr.session$rescale.session <- rescale.session
 
    # set s3 class and create attributes
-   .file_reset(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
+   .reset.files(OI = obj.info, SI = set.info, SO = set.obj, pos.info = pos.info) # recreate original file formats
    OUT <- list(set.info = set.info, obj.info = obj.info, set.obj = set.obj)
    plr.out <- .new_plr(BASE = OUT, plr_data = plr.data, plr_args = plr.args,
                        plr_summary = plr.summary, plr_seed = plr.seed,


### PR DESCRIPTION
## Summary
Standardizes internal function naming from underscore-style to dot-style for consistency with R conventions.

## Changes
Renamed 11 internal functions:
| Old Name | New Name |
|----------|----------|
| .file_set | .set.files |
| .file_reset | .reset.files |
| .get_obj_stat | .get.object.stats |
| .final_merge | .merge.final |
| .get_subnetworks | .get.subnetworks |
| .merge_sim_sets | .merge.similar.sets |
| .cap_probs | .cap.probabilities |
| .est_ss_cov | .estimate.setsize.covariance |
| .get_cgm_bins | .get.correlogram.bins |
| .get_covariance_null | .get.null.covariance |
| .get_covariance | .get.covariance |

Deprecated aliases retained for backward compatibility.

## Issues Addressed
- Issue #23: Inconsistent naming conventions (Issue #6)

## Files Modified
- R/internal.R
- R/permute.R
- R/prune.R
- R/read.R
- R/rescale.R