### PR TITLE
refactor: extract duplicated warning/message pattern to helper

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -12,6 +12,32 @@
 }
 
 
+#' @title Report accumulated messages and warnings
+#' @description Centralized reporting of info/warning messages collected
+#' during argument validation.\#' @noRd
+.report_messages <- function() {
+   .verbose_msg("\n")
+   
+   # Report warnings
+   if (!is.null(warning.messages)) {
+      warning(warning.messages, immediate. = TRUE, call. = FALSE)
+   }
+   if (!is.null(param.warnings)) {
+      warning(param.warnings, immediate. = TRUE, call. = FALSE)
+   }
+   
+   # Report info messages
+   if (!is.null(info.messages)) {
+      .verbose_msg(paste0("\n", info.messages, "\n"))
+   }
+   if (!is.null(param.messages)) {
+      .verbose_msg(paste0("\n", param.messages, "\n"))
+   }
+   
+   .verbose_msg("\n")
+}
+
+
 #' @title Internal file path checker
 #' @description An internal function to check for correct file paths for
 #'  the required input files. User can either provide path to folder with all

--- a/R/permute.R
+++ b/R/permute.R
@@ -281,12 +281,7 @@ permute_polylinkr_data <- function(plr_input, permute = TRUE, n_permutations = 5
                   align = "center", col = "cyan", border_col = "cyan"))
 
    # report collated warnings and messages
-   .verbose_msg("\n")
-   if (!is.null(WMSS)) warning(WMSS, immediate. = T, call. = F)
-   if (!is.null(MSS)) .verbose_msg(paste0("\n", MSS, "\n"))
-   if (!is.null(pWMSS)) warning(pWMSS, immediate. = T, call. = F)
-   if (!is.null(pMSS)) .verbose_msg(paste0("\n", pMSS, "\n"))
-   .verbose_msg("\n")
+   .report_messages()
 
    ##=========================================================================##
    ## PART 2: Calculate standardised gene scores

--- a/R/prune.R
+++ b/R/prune.R
@@ -176,12 +176,7 @@ prune_polylinkr_data <- function(plr_input, n_fdr = 300L, estimate_pi0 = TRUE,
                   align = "center", col = "cyan", border_col = "cyan"))
 
    # report collated warnings and messages
-   .verbose_msg("\n")
-   if (!is.null(WMSS)) warning(WMSS, immediate. = T, call. = F)
-   if (!is.null(MSS)) .verbose_msg(paste0("\n", MSS, "\n"))
-   if (!is.null(pWMSS)) warning(pWMSS, immediate. = T, call. = F)
-   if (!is.null(pMSS)) .verbose_msg(paste0("\n", pMSS, "\n"))
-   .verbose_msg("\n")
+   .report_messages()
 
    ##=========================================================================##
    ##PART 2: generate FDR sets and empirical prepare objects for pruning step

--- a/R/rescale.R
+++ b/R/rescale.R
@@ -250,12 +250,7 @@ rescale_polylinkr_data <- function(plr_input, rescale = TRUE, fast = TRUE, ac = 
                   align = "center", col = "cyan", border_col = "cyan"))
 
    # report collated warnings and messages
-   .verbose_msg("\n")
-   if (!is.null(WMSS)) warning(WMSS, immediate. = T, call. = F)
-   if (!is.null(MSS)) .verbose_msg(paste0("\n", MSS, "\n"))
-   if (!is.null(pWMSS)) warning(pWMSS, immediate. = T, call. = F)
-   if (!is.null(pMSS)) .verbose_msg(paste0("\n", pMSS, "\n"))
-   .verbose_msg("\n")
+   .report_messages()
 
    ##==========================================================================##
    ## PART 2: Calculate genomic autocovariance


### PR DESCRIPTION
## Summary
Extracts the 7-line warning/message reporting pattern that was duplicated in permute.R, prune.R, and rescale.R into a new .report_messages() helper function.

## Changes
- Added .report_messages() helper in R/internal.R
- Replaced duplicated pattern in R/permute.R, R/prune.R, R/rescale.R

## Issues Addressed
- Issue #23: Duplicated warning pattern (Issue #9)

## Code Reduction
- 18 lines removed (7 from each of 3 files)
- 29 lines added (26 for helper + 3 one-line calls)
- Net reduction of duplicated code